### PR TITLE
Still more performant even with modern Perl.

### DIFF
--- a/benchmarks/bench.pl
+++ b/benchmarks/bench.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 

--- a/benchmarks/io.pl
+++ b/benchmarks/io.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;

--- a/lib/Unicode/UTF8.pod
+++ b/lib/Unicode/UTF8.pod
@@ -157,7 +157,9 @@ Preserves taintedness of decoded C<$octets> or encoded C<$string>
 =item *
 
 Better performance ~ 600% - 1200% (JA: 600%, AR: 700%, SV: 900%, EN: 1200%, 
-see benchmarks directory in git repository)
+see benchmarks directory in git repository).
+
+With modern Perl (v5.40.1)/Encode (v3.21): Performance ~ -24% - 174% (JA: -24%, AR: 16%, SV: 91%, EN: 174%).
 
 =back
 


### PR DESCRIPTION
I became aware of this module because of a recommendation in Path::Tiny. The pod refers to a performance gain. Since I have to process a CSV file with 585M and 1105696 lines, I tried out the module straight away: If you use modern Perl, the gains are significantly lower. Apparently there has been a considerable improvement in the Encode module, because the gains also dwindle if you use the latest version of Encode, e.g. under perl 5.8.1.

Since further gains in the performance of Perl are to be expected as time goes on, you can point out here that the gains are dwindling and give an indication of whether further development can be expected here.