### PR TITLE
Add basic CI pipeline to tests different versions of Perl on PRs/merge

### DIFF
--- a/.github/cpanfile.test
+++ b/.github/cpanfile.test
@@ -1,0 +1,13 @@
+requires 'ExtUtils::MakeMaker';
+requires 'Module::Install';
+requires 'Module::Install::ReadmeFromPod';
+
+on 'test' => sub {
+    requires 'Test::More'  => '0.47';
+    requires 'Test::Fatal' => '0.006';
+    requires 'Encode'           => '1.9801';
+    requires 'Test::LeakTrace'  => '0.10';
+    requires 'Taint::Runtime'   => '0.03';
+    requires 'Variable::Magic';
+    requires 'Test::Pod'        => '1.00';
+};

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,193 @@
+name: 'Build & Test'
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - main
+    tags-ignore:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+
+###
+### Fast Test on System Perl
+###
+
+  ubuntu-latest:
+    runs-on: ubuntu-latest
+
+    env:
+      PERL_USE_UNSAFE_INC: 0
+      AUTHOR_TESTING: 1
+      AUTOMATED_TESTING: 1
+      RELEASE_TESTING: 1
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: perl -V
+      - name: install deps using cpm
+        uses: perl-actions/install-with-cpm@v1
+        with:
+          sudo: false
+          global: false
+          cpanfile: ".github/cpanfile.test"
+          args: "--with-all"
+      - name: Set PERL5LIB to local lib
+        run: echo "PERL5LIB=$(pwd)/local/lib/perl5" >> $GITHUB_ENV
+      - run: perl Makefile.PL
+      - run: make
+      - run: make test
+
+###
+### Fast Test on System Perl with user install
+###
+
+  ubuntu-latest-user:
+    runs-on: ubuntu-latest
+    needs: [ubuntu-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: perl -V
+      - name: install deps using cpm
+        uses: perl-actions/install-with-cpm@v1
+        with:
+          sudo: false
+          global: false
+          cpanfile: ".github/cpanfile.test"
+      - name: Set PERL5LIB to local lib
+        run: echo "PERL5LIB=$(pwd)/local/lib/perl5" >> $GITHUB_ENV
+      - run: perl Makefile.PL
+      - run: make
+      - run: make test
+
+###
+### linux testing multiple Perl versions
+###
+
+  perl-versions:
+    runs-on: ubuntu-latest
+    name: List Perl versions
+    outputs:
+      perl-versions: ${{ steps.action.outputs.perl-versions }}
+    steps:
+      - id: action
+        uses: perl-actions/perl-versions@v1
+        with:
+          since-perl: v5.8
+          with-devel: true
+
+  linux:
+    runs-on: ubuntu-latest
+    name: "perl ${{ matrix.perl-version }}"
+
+    needs:
+      - ubuntu-latest
+      - perl-versions
+
+    strategy:
+      fail-fast: false
+      matrix:
+        perl-version: ${{ fromJson (needs.perl-versions.outputs.perl-versions) }}
+
+    container:
+      image: perldocker/perl-tester:${{ matrix.perl-version }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: perl -V
+      - name: install deps using cpm
+        uses: perl-actions/install-with-cpm@v1
+        with:
+          sudo: false
+          cpanfile: ".github/cpanfile.test"
+          args: "--with-all"
+      - name: Set PERL5LIB to local lib
+        run: echo "PERL5LIB=$(pwd)/local/lib/perl5" >> $GITHUB_ENV
+      - run: perl Makefile.PL
+      - run: make
+      - run: make test
+        env:
+          AUTHOR_TESTING: 1
+          AUTOMATED_TESTING: 1
+          RELEASE_TESTING: 1
+
+
+  distro-matrix:
+
+    runs-on: ubuntu-latest
+    needs: [ubuntu-latest]
+    name: "test distro ${{ matrix.os-version }}"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os-version:
+          - debian:trixie
+          - debian:bullseye
+          - debian:bookworm
+          - ubuntu:20.04
+
+    container: ${{ matrix.os-version }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          (apt-get update &&
+          apt-get install -y perl make gcc sudo curl) ||
+          (yum install --skip-broken -y openssl perl make gcc sudo curl)
+      - run: perl -V
+      - name: install deps using cpm
+        uses: perl-actions/install-with-cpm@v1
+        with:
+            sudo: false
+            cpanfile: ".github/cpanfile.test"
+            args: "--with-all"
+      - name: Set PERL5LIB to local lib
+        run: echo "PERL5LIB=$(pwd)/local/lib/perl5" >> $GITHUB_ENV
+      - run: perl Makefile.PL
+      - run: make
+      - run: make test
+        env:
+          AUTHOR_TESTING: 1
+          AUTOMATED_TESTING: 1
+          RELEASE_TESTING: 1
+
+
+  windows-latest:
+    runs-on: windows-latest
+    needs: [ubuntu-latest]
+    env:
+      PERL_USE_UNSAFE_INC: 0
+      AUTHOR_TESTING: 1
+      AUTOMATED_TESTING: 1
+      RELEASE_TESTING: 1
+
+
+    steps:
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+      - uses: actions/checkout@v4
+      - name: Set up Perl
+        run: |
+          choco install strawberryperl
+          echo "C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: perl -V
+        run: perl -V
+      - name: Install Dependencies
+        run: |
+          cpanm --installdeps --cpanfile .github/cpanfile.test --with-develop .
+          cpanm -n TAP::Formatter::GitHubActions
+      - name: Run Tests
+        run: |
+          prove --merge --formatter TAP::Formatter::GitHubActions -l t
+          perl Makefile.PL
+          gmake
+          gmake test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,6 +162,7 @@ jobs:
   windows-latest:
     runs-on: windows-latest
     needs: [ubuntu-latest]
+    continue-on-error: true
     env:
       PERL_USE_UNSAFE_INC: 0
       AUTHOR_TESTING: 1


### PR DESCRIPTION
view clean pipeline here https://github.com/atoomic/p5-unicode-utf8/actions/runs/22293835844

note: Windows CI is ont clean, and can be addressed as follow up, this is currently marked as `continue-on-error: true` as we know it s failing, but we can read the errors and fix them one after the other 