### PR TITLE
Replace deprecated utf8n_to_uvuni

### DIFF
--- a/UTF8.xs
+++ b/UTF8.xs
@@ -178,7 +178,7 @@ xs_utf8_encode_replace(pTHX_ SV *dsv, const U8 *src, STRLEN len, STRLEN off, CV 
         len -= off;
         pos += utf8_length(src - off, src);
 
-        v = utf8n_to_uvuni(src, len, &skip, (UTF8_ALLOW_ANYUV|UTF8_CHECK_ONLY) & ~UTF8_ALLOW_LONG);
+        v = utf8n_to_uvchr(src, len, &skip, (UTF8_ALLOW_ANYUV|UTF8_CHECK_ONLY) & ~UTF8_ALLOW_LONG);
         if (skip == (STRLEN) -1) {
             skip = 1;
             if (UTF8_IS_START(*src)) {


### PR DESCRIPTION
... with utf8n_to_uvchr.

Today, while testing a program being used as a diagnostic for an issue in the Perl 5 bug queue, I had occasion to observe Unicode-UTF8 being downloaded from CPAN and installed against various recent perl executables.  My attention was caught by several build-time warnings like these:
```
$ ./bin/cpan -t Unicode::UTF8
Reading '/home/jkeenan/.cpan/Metadata'
  Database was generated on Mon, 01 Jun 2026 09:17:02 GMT
...

  /usr/home/jkeenan/testing/76f79e2fbc/bin/perl Makefile.PL -- OK
Running make for C/CH/CHANSEN/Unicode-UTF8-0.70.tar.gz
cp lib/Unicode/UTF8.pod blib/lib/Unicode/UTF8.pod
cp lib/Unicode/UTF8.pm blib/lib/Unicode/UTF8.pm
Running Mkbootstrap for UTF8 ()
chmod 644 "UTF8.bs"
"/usr/home/jkeenan/testing/76f79e2fbc/bin/perl" -MExtUtils::Command::MM -e 'cp_nonempty' -- UTF8.bs blib/arch/auto/Unicode/UTF8/UTF8.bs 644
"/usr/home/jkeenan/testing/76f79e2fbc/bin/perl" "/home/jkeenan/testing/76f79e2fbc/lib/perl5/5.43.11/ExtUtils/xsubpp" -noprototypes -typemap '/home/jkeenan/testing/76f79e2fbc/lib/perl5/5.43.11/ExtUtils/typemap'  UTF8.xs > UTF8.xsc
mv UTF8.xsc UTF8.c
cc -c    -DHAS_FPSETMASK -DHAS_FLOATINGPOINT_H -DNO_POSIX_2008_LOCALE -fno-strict-aliasing -pipe -fstack-protector-strong -I/usr/local/include -O2 -pipe -fstack-protector -fno-strict-aliasing    -DVERSION=\"0.70\"  -DXS_VERSION=\"0.70\" -DPIC -fPIC "-I/home/jkeenan/testing/76f79e2fbc/lib/perl5/5.43.11/amd64-freebsd-thread-multi/CORE"   UTF8.c
UTF8.xs:175:13: warning: 'Perl_utf8n_to_uvuni' is deprecated [-Wdeprecated-declarations]
  175 |         v = utf8n_to_uvuni(src, len, &skip, (UTF8_ALLOW_ANYUV|UTF8_CHECK_ONLY) & ~UTF8_ALLOW_LONG);
      |             ^
/home/jkeenan/testing/76f79e2fbc/lib/perl5/5.43.11/amd64-freebsd-thread-multi/CORE/embed.h:915:49: note: expanded from macro 'utf8n_to_uvuni'
  915 | #   define utf8n_to_uvuni(a,b,c,d)              Perl_utf8n_to_uvuni(aTHX_ a,b,c,d)
      |                                                 ^
/home/jkeenan/testing/76f79e2fbc/lib/perl5/5.43.11/amd64-freebsd-thread-multi/CORE/proto.h:7924:9: note: 'Perl_utf8n_to_uvuni' has been explicitly marked deprecated here
 7924 |         __attribute__deprecated__;
      |         ^
/home/jkeenan/testing/76f79e2fbc/lib/perl5/5.43.11/amd64-freebsd-thread-multi/CORE/perl.h:434:60: note: expanded from macro '__attribute__deprecated__'
  434 | #  define __attribute__deprecated__         __attribute__((deprecated))
      |                                                            ^
1 warning generated.
rm -f blib/arch/auto/Unicode/UTF8/UTF8.so
cc  -shared  -L/usr/local/lib -fstack-protector-strong  UTF8.o  -o blib/arch/auto/Unicode/UTF8/UTF8.so        
chmod 755 blib/arch/auto/Unicode/UTF8/UTF8.so
(/usr/bin/make exited with 0)
CPAN::Reporter: make result is 'pass', No errors.
  CHANSEN/Unicode-UTF8-0.70.tar.gz
  /usr/bin/make -- OK
```
In no case did `make test` fail.

This patch, which implements a change recommended in a comment in ppport.h, eliminates the build-time warning.  Tested on Ubuntu Linux 24.04 (unthreaded) and FreeBSD-14 (threaded).